### PR TITLE
Fix sin and tan exceptions expectations

### DIFF
--- a/test/testcases/directed/sin.tst
+++ b/test/testcases/directed/sin.tst
@@ -23,5 +23,5 @@ func=sin op1=7ff00000.00000000 result=7ff80000.00000001 errno=EDOM status=i
 func=sin op1=fff00000.00000000 result=7ff80000.00000001 errno=EDOM status=i
 func=sin op1=00000000.00000000 result=00000000.00000000 errno=0
 func=sin op1=80000000.00000000 result=80000000.00000000 errno=0
-func=sin op1=00000000.00000001 result=00000000.00000001 errno=0 status=ux
-func=sin op1=80000000.00000001 result=80000000.00000001 errno=0 status=ux
+func=sin op1=00000000.00000001 result=00000000.00000001 errno=0 status=x maybestatus=u
+func=sin op1=80000000.00000001 result=80000000.00000001 errno=0 status=x maybestatus=u

--- a/test/testcases/directed/tan.tst
+++ b/test/testcases/directed/tan.tst
@@ -21,5 +21,5 @@ func=tan op1=7ff00000.00000000 result=7ff80000.00000001 errno=EDOM status=i
 func=tan op1=fff00000.00000000 result=7ff80000.00000001 errno=EDOM status=i
 func=tan op1=00000000.00000000 result=00000000.00000000 errno=0
 func=tan op1=80000000.00000000 result=80000000.00000000 errno=0
-func=tan op1=00000000.00000001 result=00000000.00000001 errno=0 status=ux
-func=tan op1=80000000.00000001 result=80000000.00000001 errno=0 status=ux
+func=tan op1=00000000.00000001 result=00000000.00000001 errno=0 status=x maybestatus=u
+func=tan op1=80000000.00000001 result=80000000.00000001 errno=0 status=x maybestatus=u


### PR DESCRIPTION
POSIX [1] [2] states for sin/tan that if the input is subnormal, a range
error *may* occur.  It allows implementation to not set FE_UNDERFLOW in
such cases (for instance FreeBSD and Android on aarch64/arm). 

This patch sets the subnormal cases in sin/tan to have a maybestatus
instead of status.

[1] http://pubs.opengroup.org/onlinepubs/9699919799/functions/sin.html
[2] http://pubs.opengroup.org/onlinepubs/9699919799/functions/tan.html