### PR TITLE
Fix single tanf exception return for Infinity

### DIFF
--- a/math/single/s_tanf.c
+++ b/math/single/s_tanf.c
@@ -53,10 +53,7 @@ float tanf(float x)
         unsigned k = fai(x) << 1;
         if (k < 0xFF000000)            /* tiny */
             return FLOAT_CHECKDENORM(x);
-        else if (k == 0xFF000000)      /* inf */
-            return MATHERR_TANF_INF(x);
-        else                           /* NaN */
-            return FLOAT_INFNAN(x);
+       return __math_invalidf (x);
     }
 
     /*

--- a/math/tanf.c
+++ b/math/tanf.c
@@ -1,1 +1,4 @@
+#if WANT_SINGLEPREC
+#include "math_config.h"
 #include "single/s_tanf.c"
+#endif


### PR DESCRIPTION
When running optimize-routines tests on Android I am seeing:

(stdin):2512: FAIL: func=tanf op1=7f800000 result=7fc00001 errno=EDOM status=i wrongstatus=OK
(stdin):2513: FAIL: func=tanf op1=7f800000 result=7fc00001 errno=EDOM status=i errno_in=EDOM wrongstatus=OK
(stdin):2514: FAIL: func=tanf op1=7f800000 result=7fc00001 errno=EDOM status=i errno_in=ERANGE wrongstatus=OK
(stdin):2515: FAIL: func=tanf op1=ff800000 result=7fc00001 errno=EDOM status=i wrongstatus=OK
(stdin):2516: FAIL: func=tanf op1=ff800000 result=7fc00001 errno=EDOM status=i errno_in=EDOM wrongstatus=OK
(stdin):2517: FAIL: func=tanf op1=ff800000 result=7fc00001 errno=EDOM status=i errno_in=ERANGE wrongstatus=OK

This patch uses the math_config.h __math_invalidf to force the
FE_INEXACT exception for infinity case.

It also only enables tanf if WANT_SINGLEPREC is set.