### PR TITLE
string: Fix strnlen return value

### DIFF
--- a/string/aarch64/strnlen-sve.S
+++ b/string/aarch64/strnlen-sve.S
@@ -68,7 +68,7 @@ ENTRY_ALIGN (__strnlen_aarch64_sve, 4)
 	b	1b
 
 	/* End of count.  Return max.  */
-9:	mov	x0, x2
+9:	mov	x0, x1
 	ret
 
 END (__strnlen_aarch64_sve)


### PR DESCRIPTION
The comment on the eos-not-found path says that it is
returning the max string length, but it actually uses
the current string length.  This results in returned
values larger than the expected value.