### PR TITLE
string/test: Fix strrchr '\0' error report

### DIFF
--- a/string/test/strrchr.c
+++ b/string/test/strrchr.c
@@ -91,7 +91,7 @@ test (const struct fun *fun, int align, int seekpos, int len)
   if (p != s + len)
     {
       ERR ("%s (%p, 0x%02x) len %d returned %p, expected %p pos %d\n",
-	   fun->name, s, 0, len, p, f, len);
+	   fun->name, s, 0, len, p, s + len, len);
       quote ("input", s, len);
     }
 }


### PR DESCRIPTION
The error report was copied from the seekchar test above,
and needs adjustment to match the gating IF.