### PR TITLE
Update memcpy-advsimd.S to preload the src into L1 at beginning of th…

### DIFF
--- a/string/aarch64/memcpy-advsimd.S
+++ b/string/aarch64/memcpy-advsimd.S
@@ -55,6 +55,7 @@ ENTRY (__memcpy_aarch64_simd)
 	PTR_ARG (0)
 	PTR_ARG (1)
 	SIZE_ARG (2)
+	prfm    PLDL1KEEP, [src]
 	add	srcend, src, count
 	add	dstend, dstin, count
 	cmp	count, 128


### PR DESCRIPTION
…e function

In bionic benchmark on Android, with the preload instruction, memcpy performed 7.5% better on 16 bytes and 32 bytes benchmark without affecting performance of any other benchmark results.