### PR TITLE
math/aarch64: fix include path

### DIFF
--- a/math/aarch64/advsimd/finite_pow.h
+++ b/math/aarch64/advsimd/finite_pow.h
@@ -5,7 +5,7 @@
  * SPDX-License-Identifier: MIT OR Apache-2.0 WITH LLVM-exception
  */
 
-#include "math_config.h"
+#include "../../math_config.h"
 
 /* Scalar version of pow used for fallbacks in vector implementations.  */
 

--- a/math/aarch64/advsimd/v_math.h
+++ b/math/aarch64/advsimd/v_math.h
@@ -20,7 +20,7 @@
 #define V_NAME_D2(fun) _ZGVnN2vv_##fun
 
 #include <stdint.h>
-#include "math_config.h"
+#include "../../math_config.h"
 #include <arm_neon.h>
 
 /* Shorthand helpers for declaring constants.  */

--- a/math/aarch64/advsimd/v_poly_f32.h
+++ b/math/aarch64/advsimd/v_poly_f32.h
@@ -16,7 +16,7 @@
 #define VTYPE float32x4_t
 #define FMA(x, y, z) vfmaq_f32 (z, x, y)
 #define VWRAP(f) v_##f##_f32
-#include "poly_generic.h"
+#include "../../poly_generic.h"
 #undef VWRAP
 #undef FMA
 #undef VTYPE

--- a/math/aarch64/advsimd/v_poly_f64.h
+++ b/math/aarch64/advsimd/v_poly_f64.h
@@ -16,7 +16,7 @@
 #define VTYPE float64x2_t
 #define FMA(x, y, z) vfmaq_f64 (z, x, y)
 #define VWRAP(f) v_##f##_f64
-#include "poly_generic.h"
+#include "../../poly_generic.h"
 #undef VWRAP
 #undef FMA
 #undef VTYPE

--- a/math/aarch64/v_erf_data.c
+++ b/math/aarch64/v_erf_data.c
@@ -5,7 +5,7 @@
  * SPDX-License-Identifier: MIT OR Apache-2.0 WITH LLVM-exception
  */
 
-#include "math_config.h"
+#include "../math_config.h"
 
 /* Lookup table used in vector erf.
    For each possible rounded input r (multiples of 1/128), between

--- a/math/aarch64/v_erfc_data.c
+++ b/math/aarch64/v_erfc_data.c
@@ -5,7 +5,7 @@
  * SPDX-License-Identifier: MIT OR Apache-2.0 WITH LLVM-exception
  */
 
-#include "math_config.h"
+#include "../math_config.h"
 
 /* Lookup table used in vector erfc.
    For each possible rounded input r (multiples of 1/128), between

--- a/math/aarch64/v_erfcf_data.c
+++ b/math/aarch64/v_erfcf_data.c
@@ -5,7 +5,7 @@
  * SPDX-License-Identifier: MIT OR Apache-2.0 WITH LLVM-exception
  */
 
-#include "math_config.h"
+#include "../math_config.h"
 
 /* Lookup table used in vector erfcf.
    For each possible rounded input r (multiples of 1/64), between

--- a/math/aarch64/v_erff_data.c
+++ b/math/aarch64/v_erff_data.c
@@ -5,7 +5,7 @@
  * SPDX-License-Identifier: MIT OR Apache-2.0 WITH LLVM-exception
  */
 
-#include "math_config.h"
+#include "../math_config.h"
 
 /* Lookup table used in vector erff.
    For each possible rounded input r (multiples of 1/128), between

--- a/math/aarch64/v_exp_data.c
+++ b/math/aarch64/v_exp_data.c
@@ -5,7 +5,7 @@
  * SPDX-License-Identifier: MIT OR Apache-2.0 WITH LLVM-exception
  */
 
-#include "math_config.h"
+#include "../math_config.h"
 
 /* 2^(j/N), j=0..N, N=2^7=128.  */
 const uint64_t __v_exp_data[] = {

--- a/math/aarch64/v_exp_tail_data.c
+++ b/math/aarch64/v_exp_tail_data.c
@@ -5,7 +5,7 @@
  * SPDX-License-Identifier: MIT OR Apache-2.0 WITH LLVM-exception
  */
 
-#include "math_config.h"
+#include "../math_config.h"
 
 /* 2^(j/N), j=0..N, N=2^8=256.  */
 const uint64_t __v_exp_tail_data[] = {

--- a/math/aarch64/v_log10_data.c
+++ b/math/aarch64/v_log10_data.c
@@ -5,7 +5,7 @@
  * SPDX-License-Identifier: MIT OR Apache-2.0 WITH LLVM-exception
  */
 
-#include "math_config.h"
+#include "../math_config.h"
 
 const struct v_log10_data __v_log10_data = {
   /* Computed from log's coefficients div by log(10) then rounded to double

--- a/math/aarch64/v_log2_data.c
+++ b/math/aarch64/v_log2_data.c
@@ -5,7 +5,7 @@
  * SPDX-License-Identifier: MIT OR Apache-2.0 WITH LLVM-exception
  */
 
-#include "math_config.h"
+#include "../math_config.h"
 
 #define N (1 << V_LOG2_TABLE_BITS)
 

--- a/math/aarch64/v_log_data.c
+++ b/math/aarch64/v_log_data.c
@@ -5,7 +5,7 @@
  * SPDX-License-Identifier: MIT OR Apache-2.0 WITH LLVM-exception
  */
 
-#include "math_config.h"
+#include "../math_config.h"
 
 const struct v_log_data __v_log_data = {
   /* Worst-case error: 1.17 + 0.5 ulp.

--- a/math/aarch64/v_pow_exp_data.c
+++ b/math/aarch64/v_pow_exp_data.c
@@ -5,7 +5,7 @@
  * SPDX-License-Identifier: MIT OR Apache-2.0 WITH LLVM-exception
  */
 
-#include "math_config.h"
+#include "../math_config.h"
 
 #define N (1 << V_POW_EXP_TABLE_BITS)
 

--- a/math/aarch64/v_pow_log_data.c
+++ b/math/aarch64/v_pow_log_data.c
@@ -5,7 +5,7 @@
  * SPDX-License-Identifier: MIT OR Apache-2.0 WITH LLVM-exception
  */
 
-#include "math_config.h"
+#include "../math_config.h"
 
 #define N (1 << V_POW_LOG_TABLE_BITS)
 

--- a/math/aarch64/v_powf_data.c
+++ b/math/aarch64/v_powf_data.c
@@ -5,7 +5,7 @@
  * SPDX-License-Identifier: MIT OR Apache-2.0 WITH LLVM-exception
  */
 
-#include "math_config.h"
+#include "../math_config.h"
 
 const struct v_powf_data __v_powf_data = {
   .invc = { 0x1.6489890582816p+0,


### PR DESCRIPTION
This fix is to solve below error when building:
math/aarch64/v_erfc_data.c:8:10: fatal error: math_config.h: No such file or directory


Signed-off-by: Dan Zheng <dzheng@redhat.com>