### PR TITLE
Corrected comment in add sv_expf_inline.h

### DIFF
--- a/math/aarch64/sve/sv_expf_inline.h
+++ b/math/aarch64/sve/sv_expf_inline.h
@@ -52,7 +52,7 @@ expf_inline (svfloat32_t x, const svbool_t pg, const struct sv_expf_data *d)
   /* scale = 2^(n/N).  */
   svfloat32_t scale = svexpa (svreinterpret_u32 (z));
 
-  /* y = exp(r) - 1 ~= r + C0 r^2 + C1 r^3 + C2 r^4 + C3 r^5 + C4 r^6.  */
+  /* poly(r) = exp(r) - 1 ~= C0 r + C1 r^2 + C2 r^3 + C3 r^4 + C4 r^5.  */
   svfloat32_t p12 = svmla_lane (sv_f32 (d->c1), r, lane_consts, 2);
   svfloat32_t p34 = svmla_lane (sv_f32 (d->c3), r, lane_consts, 3);
   svfloat32_t r2 = svmul_x (svptrue_b32 (), r, r);


### PR DESCRIPTION
In `sv_expf_inline.h`, lines 55 to 63:
```
/* y = exp(r) - 1 ~= r + C0 r^2 + C1 r^3 + C2 r^4 + C3 r^5 + C4 r^6.  */
svfloat32_t p12 = svmla_lane (sv_f32 (d->c1), r, lane_consts, 2);
svfloat32_t p34 = svmla_lane (sv_f32 (d->c3), r, lane_consts, 3);
svfloat32_t r2 = svmul_x (svptrue_b32 (), r, r);
svfloat32_t p14 = svmla_x (pg, p12, p34, r2);
svfloat32_t p0 = svmul_lane (r, lane_consts, 1);
svfloat32_t poly = svmla_x (pg, p0, r2, p14);
return svmla_x (pg, scale, scale, poly);
```

`lane_consts` contains `ln2_lo`, `c0`, `c2`, `c4`, (`lane_consts = svld1rq (svptrue_b32 (), &d->ln2_lo)`), hence:
- `p12 = svmla_lane (sv_f32 (d->c1), r, lane_consts, 2)` is computing `c1` + r `c2`
- `p34 = svmla_lane (sv_f32 (d->c3), r, lane_consts, 3)` is computing `c3` + r `c4`
- `p0 = svmul_lane (r, lane_consts, 1)` is computing r `c0`

In `p14` there is `p12` + r^2 `p34` = c1 + r `c2` + r^2 (`c3` + r `c4`) = `c1` + r `c2` + r^2 `c3` + r^3 `c4`.
`poly` will contain the values for `p0` + r^2 `p14` = r `c0` + r^2 (`c1` + r `c2` + r^2 `c3` + r^3 `c4`) = r `c0` + r^2 `c1` + r^3 `c2` + r^4 `c3` + r^5 `c4`
Finally the returned value is `scale` + `scale` * `poly` = `scale` (1 + `poly`) = `scale` * exp(r).

Hence `poly` is a polynomial of degree 5, not 6 as written in the comment, and the coefficients have to be changed accordingly (`c0` with r, `c1` with r^2, etc.).
Since on line 42 the final result has been defined as `exp(x) = 2^n (1 + poly(r))` and `y` is not used elsewhere, I would also change the `y` on line 55 with `poly(r)`.

The error may come from `exp.c` where `c0` is the coefficient of r^2:
```
/* y = exp(r) - 1 ~= r + C0 r^2 + C1 r^3 + C2 r^4 + C3 r^5.  */
svfloat64_t r2 = svmul_x (pg, r, r);
svfloat64_t p01 = svmla_x (pg, C (0), C (1), r);
svfloat64_t p23 = svmla_x (pg, C (2), C (3), r);
svfloat64_t p04 = svmla_x (pg, p01, p23, r2);
svfloat64_t y = svmla_x (pg, r, p04, r2);
svfloat64_t s = svexpa (u);
return svmla_x (pg, s, s, y)
```