### PR TITLE
bench: fix bugs that will trucating random test size for memcpy and m…

### DIFF
--- a/string/bench/memcpy.c
+++ b/string/bench/memcpy.c
@@ -38,7 +38,7 @@ typedef struct { uint8_t align; uint16_t freq; } align_data_t;
 
 #define SIZE_NUM 65536
 #define SIZE_MASK (SIZE_NUM-1)
-static uint8_t size_arr[SIZE_NUM];
+static uint16_t size_arr[SIZE_NUM];
 
 /* Frequency data for memcpy of less than 4096 bytes based on SPEC2017.  */
 static freq_data_t size_freq[] =

--- a/string/bench/memset.c
+++ b/string/bench/memset.c
@@ -39,7 +39,7 @@ typedef struct { uint8_t align; uint16_t freq; } align_data_t;
 
 #define SIZE_NUM 65536
 #define SIZE_MASK (SIZE_NUM-1)
-static uint8_t len_arr[SIZE_NUM];
+static uint16_t len_arr[SIZE_NUM];
 
 /* Frequency data for memset sizes up to 4096 based on SPEC2017.  */
 static freq_data_t memset_len_freq[] =


### PR DESCRIPTION

When running random test for memcpy and memset,
the uint8_t type will truncate the original size based on SPEC2017, which will lead to a wrong result. Use uin16_t to fix it.

for example, In the memcpy test case, there is approximately twice the difference after modification compared to before modification.

After:
<img width="863" alt="Pasted Graphic" src="https://github.com/user-attachments/assets/0236fb1f-c9f6-40ec-bf87-4fb1780b8cde" />

Before:
<img width="861" alt="Pasted Graphic 1" src="https://github.com/user-attachments/assets/88c8f946-dc66-4bcf-905a-ce9aee9f7a2a" />
