### PR TITLE
asmdefs/aarch64: Make header compatible with Cygwin

### DIFF
--- a/string/aarch64/asmdefs.h
+++ b/string/aarch64/asmdefs.h
@@ -69,7 +69,7 @@ GNU_PROPERTY (FEATURE_1_AND, FEATURE_1_BTI|FEATURE_1_PAC)
   _ ## name:
 
 # define END(name)	.cfi_endproc
-#elif defined (_WIN32)
+#elif defined (_WIN32) || defined (__CYGWIN__)
 # define ENTRY_ALIAS(name)	\
   .global name		   SEP  \
   name:


### PR DESCRIPTION
Cygwin compiler does not define _WIN32 macro, yet it's COFF based environment that does not support .type and .size directives.

Upstreaming of this change was requested by https://sourceware.org/pipermail/newlib/2025/021909.html