### PR TITLE
aarch64: use .cfi_negate_ra_state

### DIFF
--- a/string/aarch64/asmdefs.h
+++ b/string/aarch64/asmdefs.h
@@ -21,8 +21,8 @@
 #define BTI_C		hint	34
 #define BTI_J		hint	36
 /* Return address signing support (pac-ret).  */
-#define PACIASP		hint	25 SEP .cfi_window_save
-#define AUTIASP		hint	29 SEP .cfi_window_save
+#define PACIASP		hint	25 SEP .cfi_negate_ra_state
+#define AUTIASP		hint	29 SEP .cfi_negate_ra_state
 
 /* GNU_PROPERTY_AARCH64_* macros from elf.h.  */
 #define FEATURE_1_AND 0xc0000000


### PR DESCRIPTION
.cfi_negate_ra_state (AArch64) and .cfi_window_save (SPARC) generate the same dwarf code.  That isn't a problem because this is all in the processor-specific part of the encoding space.  However, .cfi_negate_ra_state is the correct directive to use, since we can't assume that all AArch64 assemblers will recognize a SPARC-specific directive in this context.