### PR TITLE
string: Improve SVE memset when len is 64

### DIFF
--- a/string/aarch64/memset-sve.S
+++ b/string/aarch64/memset-sve.S
@@ -29,13 +29,13 @@
 ENTRY (__memset_aarch64_sve)
 	dup	v0.16B, valw
 	cmp	count, 16
-	b.ls	L(set_16)
+	b.lo	L(set_16)
 
 	add	dstend, dstin, count
 	cmp	count, 64
 	b.hi	L(set_128)
 
-	/* Set 17..64 bytes.  */
+	/* Set 16..64 bytes.  */
 	mov	off, 48
 	and	off, off, count, lsr 1
 	sub	dstend2, dstend, off

--- a/string/aarch64/memset-sve.S
+++ b/string/aarch64/memset-sve.S
@@ -36,9 +36,8 @@ ENTRY (__memset_aarch64_sve)
 	b.hi	L(set_128)
 
 	/* Set 16..64 bytes.  */
-	mov	val, 16
-	and	off, val, count, lsr 1
-	csel	off, val, off, eq
+	and off, count, 96
+	lsr off, off, 1
 	sub	dstend2, dstend, off
 	str	q0, [dstin]
 	str	q0, [dstin, off]

--- a/string/aarch64/memset-sve.S
+++ b/string/aarch64/memset-sve.S
@@ -35,7 +35,7 @@ ENTRY (__memset_aarch64_sve)
 	cmp	count, 64
 	b.hi	L(set_128)
 
-	/* Set 16..64 bytes.  */
+	/* Set 17..64 bytes.  */
 	and off, count, 96
 	lsr off, off, 1
 	sub	dstend2, dstend, off

--- a/string/aarch64/memset-sve.S
+++ b/string/aarch64/memset-sve.S
@@ -36,8 +36,8 @@ ENTRY (__memset_aarch64_sve)
 	b.hi	L(set_128)
 
 	/* Set 17..64 bytes.  */
-	and off, count, 96
-	lsr off, off, 1
+	mov	off, 48
+	and	off, off, count, lsr 1
 	sub	dstend2, dstend, off
 	str	q0, [dstin]
 	str	q0, [dstin, off]

--- a/string/aarch64/memset-sve.S
+++ b/string/aarch64/memset-sve.S
@@ -38,7 +38,7 @@ ENTRY (__memset_aarch64_sve)
 	/* Set 16..64 bytes.  */
 	mov	val, 16
 	and	off, val, count, lsr 1
-	csel off, val, off, eq
+	csel	off, val, off, eq
 	sub	dstend2, dstend, off
 	str	q0, [dstin]
 	str	q0, [dstin, off]

--- a/string/aarch64/memset-sve.S
+++ b/string/aarch64/memset-sve.S
@@ -29,15 +29,16 @@
 ENTRY (__memset_aarch64_sve)
 	dup	v0.16B, valw
 	cmp	count, 16
-	b.lo	L(set_16)
+	b.ls	L(set_16)
 
 	add	dstend, dstin, count
 	cmp	count, 64
-	b.hs	L(set_128)
+	b.hi	L(set_128)
 
-	/* Set 16..63 bytes.  */
-	mov	off, 16
-	and	off, off, count, lsr 1
+	/* Set 16..64 bytes.  */
+	mov	val, 16
+	and	off, val, count, lsr 1
+	csel off, val, off, eq
 	sub	dstend2, dstend, off
 	str	q0, [dstin]
 	str	q0, [dstin, off]


### PR DESCRIPTION
Improve latency of SVE memset when len is 64.

Now both the 6th and 7th bit of count are preserved on the path [17,64]. When len==64, the second memory store now access offset 32, whereas the third one accesses offset 16.