### PR TITLE
Add editorconfig and clang-format configuration files

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,16 @@
+# SPDX-License-Identifier: MIT OR Apache-2.0 WITH LLVM-exception
+# Copyright (c) 2026, Arm Limited.
+# Default style for optimized-routines. Based on GNU style with deviations to
+# match glibc style.
+---
+BasedOnStyle: GNU
+IndentPPDirectives: AfterHash
+SortIncludes:    false
+SpaceAfterCStyleCast: true
+Standard:        Cpp03
+UseTab:          Always
+ForEachMacros:
+  - 'FOR_EACH_IMPL'
+  - 'list_for_each'
+  - 'list_for_each_prev'
+  - 'list_for_each_prev_safe'

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,29 @@
+# SPDX-License-Identifier: MIT OR Apache-2.0 WITH LLVM-exception
+# Copyright (c) 2026, Arm Limited.
+
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+trim_trailing_whitespace = true
+
+[*.{c,h}]
+indent_style = tab
+indent_size = 2
+tab_width = 8
+max_line_length = 79
+
+[*.{S,s}]
+indent_style = tab
+tab_width = 8
+max_line_length = 79
+
+[{Makefile,*.mk}]
+indent_style = tab
+tab_width = 8
+
+[*.md]
+indent_style = space
+indent_size = 2
+trim_trailing_whitespace = false


### PR DESCRIPTION
These files should make following the GNU and GNU libc guidelines on formatting easier.